### PR TITLE
fix(ci): allow landing deploy from workflow_dispatch

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -54,17 +54,17 @@ jobs:
         run: pnpm build:landing
 
       - name: Setup Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: './apps/landing/dist'
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- Fix landing page not deploying when triggered from release workflow
- Changed conditions from `event_name == 'push'` to `event_name != 'pull_request'` so `workflow_dispatch` triggers also deploy

## Test plan
- [ ] Create a release and verify landing page deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)