### PR TITLE
fix(dotnet): thread-safe CefSharpBrowserBridge + auto InitResult

### DIFF
--- a/dotnet/Aspectly.Bridge.CefSharp/src/CefSharpBrowserBridge.cs
+++ b/dotnet/Aspectly.Bridge.CefSharp/src/CefSharpBrowserBridge.cs
@@ -1,3 +1,4 @@
+using System.Windows.Threading;
 using CefSharp;
 using CefSharp.Wpf;
 using Aspectly.Bridge;
@@ -7,14 +8,27 @@ namespace Aspectly.Bridge.CefSharp;
 /// <summary>
 /// IBrowserBridge implementation for CefSharp ChromiumWebBrowser.
 /// Handles message passing between .NET and JavaScript via CefSharp bindings.
+/// When a WPF Dispatcher is provided, all browser access is automatically
+/// dispatched to the UI thread (required because ChromiumWebBrowser.IsBrowserInitialized
+/// is a DependencyProperty that throws when accessed from non-UI threads).
 /// </summary>
 public class CefSharpBrowserBridge : IBrowserBridge
 {
     private readonly ChromiumWebBrowser _browser;
+    private readonly Dispatcher? _dispatcher;
     private bool _disposed;
 
     /// <inheritdoc />
-    public bool IsReady => _browser.IsBrowserInitialized;
+    public bool IsReady
+    {
+        get
+        {
+            if (_dispatcher == null || _dispatcher.CheckAccess())
+                return _browser.IsBrowserInitialized;
+
+            return _dispatcher.Invoke(() => _browser.IsBrowserInitialized);
+        }
+    }
 
     /// <inheritdoc />
     public event EventHandler<BrowserMessageEventArgs>? MessageReceived;
@@ -23,9 +37,15 @@ public class CefSharpBrowserBridge : IBrowserBridge
     /// Creates a new CefSharpBrowserBridge for the specified browser.
     /// </summary>
     /// <param name="browser">The ChromiumWebBrowser instance to bind to.</param>
-    public CefSharpBrowserBridge(ChromiumWebBrowser browser)
+    /// <param name="dispatcher">
+    /// Optional WPF Dispatcher for thread-safe browser access.
+    /// When provided, IsReady and ExecuteScriptAsync are dispatched to the UI thread.
+    /// Recommended when the bridge may be accessed from non-UI threads (e.g., CEF IO thread).
+    /// </param>
+    public CefSharpBrowserBridge(ChromiumWebBrowser browser, Dispatcher? dispatcher = null)
     {
         _browser = browser ?? throw new ArgumentNullException(nameof(browser));
+        _dispatcher = dispatcher;
         _browser.JavascriptMessageReceived += OnJavascriptMessageReceived;
     }
 
@@ -41,12 +61,23 @@ public class CefSharpBrowserBridge : IBrowserBridge
     /// <inheritdoc />
     public async Task ExecuteScriptAsync(string script)
     {
-        if (!_browser.IsBrowserInitialized)
+        if (_dispatcher == null || _dispatcher.CheckAccess())
         {
-            throw new InvalidOperationException("Browser is not initialized");
-        }
+            if (!_browser.IsBrowserInitialized)
+                throw new InvalidOperationException("Browser is not initialized");
 
-        await _browser.EvaluateScriptAsync(script);
+            await _browser.EvaluateScriptAsync(script);
+        }
+        else
+        {
+            await _dispatcher.InvokeAsync(async () =>
+            {
+                if (!_browser.IsBrowserInitialized)
+                    throw new InvalidOperationException("Browser is not initialized");
+
+                await _browser.EvaluateScriptAsync(script);
+            }).Task.Unwrap();
+        }
     }
 
     /// <inheritdoc />

--- a/dotnet/Aspectly.Bridge/src/BridgeHost.cs
+++ b/dotnet/Aspectly.Bridge/src/BridgeHost.cs
@@ -379,7 +379,8 @@ public class BridgeHost : IDisposable
     #endregion
 
     /// <summary>
-    /// Sends the Init event to JavaScript with the list of registered methods.
+    /// Sends the Init event to JavaScript with the list of registered methods,
+    /// followed by InitResult to confirm the bridge is ready.
     /// </summary>
     public async Task InitializeAsync()
     {
@@ -390,6 +391,9 @@ public class BridgeHost : IDisposable
         }
         await SendEventAsync(BridgeEventType.Init, new BridgeInitData { Methods = methods });
         _logger.Info($"[BridgeHost] Sent Init with methods: {string.Join(", ", methods)}");
+
+        await SendEventAsync(BridgeEventType.InitResult, new BridgeInitData { Methods = methods });
+        _logger.Info("[BridgeHost] Sent InitResult");
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
- CefSharpBrowserBridge now accepts optional `Dispatcher` parameter for thread-safe WPF access
- BridgeHost.InitializeAsync() automatically sends InitResult after Init

## Details
- Eliminates need for separate ThreadSafeBrowserBridge wrapper
- `IsReady` and `ExecuteScriptAsync` dispatch to UI thread when Dispatcher is provided
- Backward compatible — Dispatcher parameter is optional (default null)