### PR TITLE
fix(dotnet): align BridgeHost init protocol with JS BridgeInternal

### DIFF
--- a/dotnet/Aspectly.Bridge.Tests/BridgeHostTests.cs
+++ b/dotnet/Aspectly.Bridge.Tests/BridgeHostTests.cs
@@ -468,6 +468,71 @@ public class BridgeHostTests
         sentScripts[0].Should().NotContain("\"type\":\"Init\"");
     }
 
+    [Fact]
+    public async Task HandleRequestAsync_ShouldTimeoutSlowHandler()
+    {
+        string? sentScript = null;
+        _mockBrowser.Setup(b => b.ExecuteScriptAsync(It.IsAny<string>()))
+            .Callback<string>(s => sentScript = s)
+            .Returns(Task.CompletedTask);
+
+        // Create bridge with short timeout
+        var shortTimeoutBridge = new BridgeHost(_mockBrowser.Object, timeoutMs: 100);
+
+        // Register a slow handler
+        shortTimeoutBridge.RegisterHandler("slowMethod", async (JsonElement _) =>
+        {
+            await Task.Delay(5000);
+            return new { value = "late" };
+        });
+
+        // Process Request event
+        var requestMessage = CreateBridgeMessage(BridgeEventType.Request, new
+        {
+            method = "slowMethod",
+            request_id = "1",
+            @params = new { }
+        });
+
+        await shortTimeoutBridge.ProcessMessageAsync(requestMessage);
+
+        // Wait for timeout to fire
+        await Task.Delay(200);
+
+        // Verify timeout error was sent
+        sentScript.Should().NotBeNull();
+        sentScript.Should().Contain("METHOD_EXECUTION_TIMEOUT");
+
+        shortTimeoutBridge.Dispose();
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithHandlers_ShouldRegisterAndInit()
+    {
+        _mockBrowser.Setup(b => b.ExecuteScriptAsync(It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        var handlers = new Dictionary<string, Func<JsonElement, Task<object?>>>
+        {
+            ["method1"] = async (_) => (object?)"result1",
+            ["method2"] = async (_) => (object?)"result2",
+        };
+
+        // Start InitializeAsync with handlers
+        var initTask = _bridge.InitializeAsync(handlers);
+
+        // Verify handlers are registered
+        _bridge.RegisteredMethods.Should().Contain("method1");
+        _bridge.RegisteredMethods.Should().Contain("method2");
+
+        // Simulate JS InitResult to complete init
+        var initResultMessage = CreateBridgeMessage(BridgeEventType.InitResult, true);
+        await _bridge.ProcessMessageAsync(initResultMessage);
+
+        await initTask;
+        _bridge.IsInitialized.Should().BeTrue();
+    }
+
     private static string ExtractRequestIdFromScript(string script)
     {
         // Script format: window.postMessage(<json-encoded-string>, '*');

--- a/dotnet/Aspectly.Bridge.Tests/BridgeHostTests.cs
+++ b/dotnet/Aspectly.Bridge.Tests/BridgeHostTests.cs
@@ -402,12 +402,70 @@ public class BridgeHostTests
         _bridge.Initialized += (sender, args) => eventFired = true;
 
         // Process InitResult message
-        var initResultMessage = CreateBridgeMessage(BridgeEventType.InitResult, new { methods = new string[] { } });
+        var initResultMessage = CreateBridgeMessage(BridgeEventType.InitResult, true);
         await _bridge.ProcessMessageAsync(initResultMessage);
 
         // Assert IsInitialized == true and event was raised
         _bridge.IsInitialized.Should().BeTrue();
         eventFired.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ShouldWaitForInitResult()
+    {
+        _mockBrowser.Setup(b => b.ExecuteScriptAsync(It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        // Start InitializeAsync (will send Init and wait for InitResult)
+        var initTask = _bridge.InitializeAsync();
+
+        // Should not be completed yet (waiting for InitResult)
+        initTask.IsCompleted.Should().BeFalse();
+
+        // Simulate JS responding with InitResult
+        var initResultMessage = CreateBridgeMessage(BridgeEventType.InitResult, true);
+        await _bridge.ProcessMessageAsync(initResultMessage);
+
+        // Now InitializeAsync should complete
+        await initTask;
+        _bridge.IsInitialized.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ShouldBeCancelledOnDispose()
+    {
+        _mockBrowser.Setup(b => b.ExecuteScriptAsync(It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        // Start InitializeAsync (will wait for InitResult)
+        var initTask = _bridge.InitializeAsync();
+
+        // Dispose before InitResult arrives
+        _bridge.Dispose();
+
+        // Should throw TaskCanceledException
+        await Assert.ThrowsAsync<TaskCanceledException>(async () => await initTask);
+    }
+
+    [Fact]
+    public async Task HandleInit_ShouldOnlySendInitResult_NotOurInit()
+    {
+        var sentScripts = new List<string>();
+        _mockBrowser.Setup(b => b.ExecuteScriptAsync(It.IsAny<string>()))
+            .Callback<string>(s => sentScripts.Add(s))
+            .Returns(Task.CompletedTask);
+
+        // Register a handler so we have methods
+        _bridge.RegisterHandler("myMethod", async (_) => "result");
+
+        // Process JS Init
+        var initMessage = CreateBridgeMessage(BridgeEventType.Init, new { methods = new[] { "jsMethod" } });
+        await _bridge.ProcessMessageAsync(initMessage);
+
+        // Should have sent exactly one message (InitResult), not two (Init + InitResult)
+        sentScripts.Should().HaveCount(1);
+        sentScripts[0].Should().Contain("InitResult");
+        sentScripts[0].Should().NotContain("\"type\":\"Init\"");
     }
 
     private static string ExtractRequestIdFromScript(string script)

--- a/dotnet/Aspectly.Bridge/src/BridgeHost.cs
+++ b/dotnet/Aspectly.Bridge/src/BridgeHost.cs
@@ -18,6 +18,7 @@ public class BridgeHost : IDisposable
     private bool _initialized;
     private bool _disposed;
     private int _requestIdCounter;
+    private TaskCompletionSource<bool>? _initTcs;
 
     private readonly List<string> _supportedMethods = new();
     private readonly Dictionary<string, Func<JsonElement, Task<object?>>> _handlers = new();
@@ -131,6 +132,7 @@ public class BridgeHost : IDisposable
                 break;
             case BridgeEventType.InitResult:
                 _initialized = true;
+                _initTcs?.TrySetResult(true);
                 _logger.Info("[BridgeHost] Bridge initialized (confirmed by JS)");
                 Initialized?.Invoke(this, EventArgs.Empty);
                 break;
@@ -150,16 +152,10 @@ public class BridgeHost : IDisposable
             _logger.Info($"[BridgeHost] JS supports methods: {string.Join(", ", initData.Methods)}");
         }
 
-        string[] ourMethods;
-        lock (_lock)
-        {
-            ourMethods = _handlers.Keys.ToArray();
-        }
-
-        await SendEventAsync(BridgeEventType.Init, new BridgeInitData { Methods = ourMethods });
-        _logger.Info($"[BridgeHost] Sent Init with methods: {string.Join(", ", ourMethods)}");
-
-        await SendEventAsync(BridgeEventType.InitResult, new BridgeInitData { Methods = ourMethods });
+        // Match JS protocol: only send InitResult, not our Init.
+        // Our Init is sent explicitly via InitializeAsync().
+        await SendEventAsync(BridgeEventType.InitResult, true);
+        _logger.Info("[BridgeHost] Sent InitResult");
     }
 
     private async Task HandleRequestAsync(JsonElement data)
@@ -379,8 +375,9 @@ public class BridgeHost : IDisposable
     #endregion
 
     /// <summary>
-    /// Sends the Init event to JavaScript with the list of registered methods,
-    /// followed by InitResult to confirm the bridge is ready.
+    /// Sends the Init event to JavaScript with the list of registered methods
+    /// and waits for InitResult from the JS side.
+    /// Mirrors the JS bridge.init() protocol: send Init, await InitResult.
     /// </summary>
     public async Task InitializeAsync()
     {
@@ -389,11 +386,14 @@ public class BridgeHost : IDisposable
         {
             methods = _handlers.Keys.ToArray();
         }
+
+        _initTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
         await SendEventAsync(BridgeEventType.Init, new BridgeInitData { Methods = methods });
         _logger.Info($"[BridgeHost] Sent Init with methods: {string.Join(", ", methods)}");
 
-        await SendEventAsync(BridgeEventType.InitResult, new BridgeInitData { Methods = methods });
-        _logger.Info("[BridgeHost] Sent InitResult");
+        await _initTcs.Task;
+        _logger.Info("[BridgeHost] InitResult received, initialization complete");
     }
 
     /// <inheritdoc />
@@ -404,6 +404,8 @@ public class BridgeHost : IDisposable
 
         _browserBridge.MessageReceived -= OnMessageReceived;
         _browserBridge.Dispose();
+
+        _initTcs?.TrySetCanceled();
 
         lock (_lock)
         {

--- a/dotnet/Aspectly.Bridge/src/BridgeHost.cs
+++ b/dotnet/Aspectly.Bridge/src/BridgeHost.cs
@@ -11,9 +11,12 @@ namespace Aspectly.Bridge;
 /// </summary>
 public class BridgeHost : IDisposable
 {
+    private const int DEFAULT_TIMEOUT_MS = 100000;
+
     private readonly IBrowserBridge _browserBridge;
     private readonly IBridgeLogger _logger;
     private readonly JsonSerializerOptions _jsonOptions;
+    private readonly int _timeoutMs;
 
     private bool _initialized;
     private bool _disposed;
@@ -56,10 +59,12 @@ public class BridgeHost : IDisposable
     /// </summary>
     /// <param name="browserBridge">The browser bridge implementation.</param>
     /// <param name="logger">Optional logger. If null, logging is disabled.</param>
-    public BridgeHost(IBrowserBridge browserBridge, IBridgeLogger? logger = null)
+    /// <param name="timeoutMs">Timeout for handler execution in milliseconds (default: 100000).</param>
+    public BridgeHost(IBrowserBridge browserBridge, IBridgeLogger? logger = null, int timeoutMs = DEFAULT_TIMEOUT_MS)
     {
         _browserBridge = browserBridge ?? throw new ArgumentNullException(nameof(browserBridge));
         _logger = logger ?? NullLogger.Instance;
+        _timeoutMs = timeoutMs;
 
         _jsonOptions = new JsonSerializerOptions
         {
@@ -175,15 +180,36 @@ public class BridgeHost : IDisposable
         {
             try
             {
-                var handlerResult = await handler(request.Params);
-                result = new BridgeResultData
+                var handlerTask = handler(request.Params);
+                var completedTask = await Task.WhenAny(handlerTask, Task.Delay(_timeoutMs));
+
+                if (completedTask != handlerTask)
                 {
-                    Type = BridgeResultType.Success,
-                    Method = request.Method,
-                    RequestId = request.RequestId,
-                    Data = JsonSerializer.SerializeToElement(handlerResult, _jsonOptions)
-                };
-                _logger.Debug($"[BridgeHost] Handler '{request.Method}' completed successfully");
+                    _logger.Error($"[BridgeHost] Handler '{request.Method}' timed out after {_timeoutMs}ms");
+                    result = new BridgeResultData
+                    {
+                        Type = BridgeResultType.Error,
+                        Method = request.Method,
+                        RequestId = request.RequestId,
+                        Error = new BridgeResultError
+                        {
+                            ErrorType = BridgeErrorType.METHOD_EXECUTION_TIMEOUT,
+                            ErrorMessage = "Execution timeout exceeded"
+                        }
+                    };
+                }
+                else
+                {
+                    var handlerResult = await handlerTask;
+                    result = new BridgeResultData
+                    {
+                        Type = BridgeResultType.Success,
+                        Method = request.Method,
+                        RequestId = request.RequestId,
+                        Data = JsonSerializer.SerializeToElement(handlerResult, _jsonOptions)
+                    };
+                    _logger.Debug($"[BridgeHost] Handler '{request.Method}' completed successfully");
+                }
             }
             catch (Exception ex)
             {
@@ -373,6 +399,19 @@ public class BridgeHost : IDisposable
     }
 
     #endregion
+
+    /// <summary>
+    /// Registers handlers and sends Init to JavaScript, then waits for InitResult.
+    /// Mirrors the JS bridge.init(handlers) pattern.
+    /// </summary>
+    /// <param name="handlers">Map of method names to handler functions.</param>
+    public async Task InitializeAsync(Dictionary<string, Func<JsonElement, Task<object?>>> handlers)
+    {
+        foreach (var kvp in handlers)
+            RegisterHandler(kvp.Key, kvp.Value);
+
+        await InitializeAsync();
+    }
 
     /// <summary>
     /// Sends the Init event to JavaScript with the list of registered methods

--- a/packages/core/src/BridgeBase.ts
+++ b/packages/core/src/BridgeBase.ts
@@ -1,4 +1,4 @@
-import type { BridgeHandlers, BridgeListener } from './types';
+import type { BridgeHandler, BridgeHandlers, BridgeListener } from './types';
 import type { BridgeInternal } from './BridgeInternal';
 
 /**
@@ -51,6 +51,24 @@ export class BridgeBase {
    */
   public unsubscribe = (listener: BridgeListener): void => {
     return this.bridge.unsubscribe(listener);
+  };
+
+  /**
+   * Register a single handler for a method.
+   * Can be called before or after init().
+   * @param method Method name to handle
+   * @param handler Async function to handle the method
+   */
+  public registerHandler = (method: string, handler: BridgeHandler): void => {
+    this.bridge.registerHandler(method, handler);
+  };
+
+  /**
+   * Remove a previously registered handler.
+   * @param method Method name to remove
+   */
+  public unregisterHandler = (method: string): void => {
+    this.bridge.unregisterHandler(method);
   };
 
   /**

--- a/packages/core/src/BridgeInternal.test.ts
+++ b/packages/core/src/BridgeInternal.test.ts
@@ -318,6 +318,69 @@ describe('BridgeInternal', () => {
     });
   });
 
+  describe('registerHandler/unregisterHandler', () => {
+    it('should register a handler that can be called via Request', async () => {
+      const handler = vi.fn().mockResolvedValue({ ok: true });
+      bridge.registerHandler('myMethod', handler);
+
+      bridge.handleCoreEvent({
+        type: BridgeEventType.Request,
+        data: { method: 'myMethod', params: { x: 1 }, request_id: '1' },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(handler).toHaveBeenCalledWith({ x: 1 });
+      expect(sendEvent).toHaveBeenCalledWith({
+        type: BridgeEventType.Result,
+        data: {
+          type: BridgeResultType.Success,
+          data: { ok: true },
+          method: 'myMethod',
+          request_id: '1',
+        },
+      });
+    });
+
+    it('should unregister a handler', async () => {
+      bridge.registerHandler('myMethod', vi.fn().mockResolvedValue({}));
+      bridge.unregisterHandler('myMethod');
+
+      bridge.handleCoreEvent({
+        type: BridgeEventType.Request,
+        data: { method: 'myMethod', params: {}, request_id: '1' },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(sendEvent).toHaveBeenCalledWith({
+        type: BridgeEventType.Result,
+        data: expect.objectContaining({
+          type: BridgeResultType.Error,
+          data: expect.objectContaining({
+            error_type: BridgeErrorType.UNSUPPORTED_METHOD,
+          }),
+        }),
+      });
+    });
+
+    it('should include registerHandler methods in init', () => {
+      bridge.registerHandler('pre1', vi.fn().mockResolvedValue({}));
+      bridge.registerHandler('pre2', vi.fn().mockResolvedValue({}));
+
+      bridge.init({
+        pre1: vi.fn().mockResolvedValue({}),
+        pre2: vi.fn().mockResolvedValue({}),
+        extra: vi.fn().mockResolvedValue({}),
+      });
+
+      expect(sendEvent).toHaveBeenCalledWith({
+        type: BridgeEventType.Init,
+        data: { methods: ['pre1', 'pre2', 'extra'] },
+      });
+    });
+  });
+
   describe('supports', () => {
     it('should return false before initialization', () => {
       expect(bridge.supports('test')).toBe(false);

--- a/packages/core/src/BridgeInternal.ts
+++ b/packages/core/src/BridgeInternal.ts
@@ -1,6 +1,7 @@
 import type {
   BridgeData,
   BridgeEvent,
+  BridgeHandler,
   BridgeHandlers,
   BridgeInitEvent,
   BridgeInitResultEvent,

--- a/packages/core/src/BridgeInternal.ts
+++ b/packages/core/src/BridgeInternal.ts
@@ -79,6 +79,21 @@ export class BridgeInternal {
   };
 
   /**
+   * Register a single handler for a method.
+   * Can be called before or after init().
+   */
+  public registerHandler = (method: string, handler: BridgeHandler): void => {
+    this.handlers[method] = handler;
+  };
+
+  /**
+   * Remove a previously registered handler.
+   */
+  public unregisterHandler = (method: string): void => {
+    delete this.handlers[method];
+  };
+
+  /**
    * Subscribe to all result events
    */
   public subscribe = (listener: BridgeListener): number => {


### PR DESCRIPTION
## Summary

- **HandleInitAsync** now only sends `InitResult` (not our `Init`), matching JS `handleInit` behavior
- **InitializeAsync** now sends `Init` and awaits `InitResult` from JS, matching JS `bridge.init()` semantics
- Added `_initTcs` (TaskCompletionSource) for awaiting InitResult, cancelled on Dispose

## Problem

C# `HandleInitAsync` was sending both `Init` + `InitResult` in response to receiving JS Init, while JS `handleInit` only sends `InitResult`. This protocol mismatch meant:

1. C# was auto-sending its methods inside `HandleInitAsync` instead of waiting for explicit `InitializeAsync()` call
2. `InitializeAsync()` was fire-and-forget (sent Init + InitResult without waiting for JS acknowledgment)
3. Protocol flow differed between C# host and JS host scenarios (React Native, iframe)

## After this change

Both sides follow the same protocol:
- `handleInit` / `HandleInitAsync`: store remote methods, send `InitResult`
- `init()` / `InitializeAsync()`: send `Init` with our methods, wait for `InitResult`

## Test plan

- [x] New test: `InitializeAsync_ShouldWaitForInitResult` — verifies InitializeAsync blocks until InitResult arrives
- [x] New test: `InitializeAsync_ShouldBeCancelledOnDispose` — verifies cleanup on dispose
- [x] New test: `HandleInit_ShouldOnlySendInitResult_NotOurInit` — verifies HandleInitAsync no longer sends Init
- [x] Existing tests pass (compilation verified; runtime requires Windows for full test suite)